### PR TITLE
feat: Add the ability to dim the screen even more.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea
 .DS_Store
 /build
 /captures

--- a/app/src/main/java/com/flx_apps/digitaldetox/DetoxUtil.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/DetoxUtil.kt
@@ -9,6 +9,8 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
 import android.widget.Toast
+import com.flx_apps.digitaldetox.DetoxUtil.ZEN_MODE
+import com.flx_apps.digitaldetox.DetoxUtil.isZenModeEnabled
 import com.flx_apps.digitaldetox.prefs.Prefs_
 import java.util.concurrent.TimeUnit
 
@@ -20,6 +22,7 @@ import java.util.concurrent.TimeUnit
 object DetoxUtil {
     const val DISPLAY_DALTONIZER_ENABLED = "accessibility_display_daltonizer_enabled"
     const val DISPLAY_DALTONIZER = "accessibility_display_daltonizer"
+    const val EXTRA_DIM = "reduce_bright_colors_activated"
 
     const val ZEN_MODE = "zen_mode"
     const val ZEN_MODE_OFF = 0
@@ -42,7 +45,13 @@ object DetoxUtil {
      * Convenience function to (de-)activate all DetoxDroid modules
      */
     @JvmStatic
-    fun setActive(context: Context, active: Boolean, grayscale: Boolean = active, zenMode: Boolean = active, appsDeactivated: Boolean = active) {
+    fun setActive(
+        context: Context,
+        active: Boolean,
+        grayscale: Boolean = active,
+        zenMode: Boolean = active,
+        appsDeactivated: Boolean = active
+    ) {
         setGrayscale(context, grayscale)
         setZenMode(context, zenMode)
         setAppsDeactivated(context, appsDeactivated)
@@ -72,8 +81,26 @@ object DetoxUtil {
             DISPLAY_DALTONIZER,
             if (grayscale) 0 else -1
         )
+        val result3 = setExtraDim(context, grayscale)
         isGrayscale = grayscale
-        return result1 && result2
+        return result1 && result2 && result3
+    }
+
+    @JvmStatic
+    fun setExtraDim(
+        context: Context,
+        grayscale: Boolean
+    ): Boolean {
+        if (context.checkCallingOrSelfPermission("android.permission.WRITE_SECURE_SETTINGS") != PackageManager.PERMISSION_GRANTED) {
+            return false
+        }
+
+        val contentResolver = context.contentResolver
+        return Settings.Secure.putInt(
+            contentResolver,
+            EXTRA_DIM,
+            if (grayscale) 1 else 0
+        )
     }
 
     @JvmStatic

--- a/app/src/main/java/com/flx_apps/digitaldetox/prefs/ExtraDimPreference.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/prefs/ExtraDimPreference.kt
@@ -1,0 +1,125 @@
+package com.flx_apps.digitaldetox.prefs
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.text.SpannableStringBuilder
+import android.util.AttributeSet
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.widget.ImageView
+import androidx.core.text.bold
+import androidx.preference.CheckBoxPreference
+import androidx.preference.PreferenceManager
+import androidx.preference.PreferenceViewHolder
+import com.flx_apps.digitaldetox.DetoxUtil
+import com.flx_apps.digitaldetox.R
+
+/**
+ * Allows the user to
+ * - toggle 'Extra Dim' on and off
+ *   - if the preference is toggled when the service is active, it will take effect immediately
+ *   - if the preference is toggled when the service is not active, it will take effect when
+ *     the service is started (either manually or via a rule)
+ * - long-press to go to the 'Reduce Device Brightness' system
+ *   settings to adjust the intensity of the dimness.
+ * - if the service is stopped, the extra dim state will be deactivated immediately (but the
+ *   preference will be preserved for the next time the service is activated)
+ */
+class ExtraDimPreference(
+    context: Context,
+    attrs: AttributeSet? = null
+) : CheckBoxPreference(context, attrs) {
+    private var deviceIsCurrentlyExtraDim: Boolean = false
+
+    private val gestureDetector = GestureDetector(
+        context,
+        object : GestureDetector.SimpleOnGestureListener() {
+            override fun onSingleTapUp(e: MotionEvent?): Boolean {
+                performClick()
+                return true
+            }
+
+            override fun onLongPress(e: MotionEvent?) {
+                if (!deviceIsCurrentlyExtraDim) {
+                    return
+                }
+
+                // open device settings for 'reduce bright colors' intensity
+                val intent = Intent("android.settings.REDUCE_BRIGHT_COLORS_SETTINGS")
+                context.startActivity(intent)
+            }
+        }
+    )
+
+    init {
+        isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        isCopyingEnabled = false
+
+        if (isVisible) {
+            PreferenceManager.getDefaultSharedPreferences(context)
+                .registerOnSharedPreferenceChangeListener { _, key -> update(key) }
+
+            update()
+        }
+    }
+
+    private fun update(key: String? = null) {
+        val prefs = Prefs_(context)
+        when (key) {
+            // just the default init of the extra dim state of the device
+            null -> {
+                // continue
+            }
+            // one of the shared preferences that may affect the extra dim state of the device
+            prefs.isRunning.key(),
+            prefs.grayscaleEnabled().key(),
+            prefs.grayscaleExtraDim().key() -> {
+                // continue
+            }
+            // other shared preferences that are irrelevant to the extra dim state of the device
+            else -> return
+        }
+
+        val serviceRunning = prefs.isRunning.get()
+        val newValue = prefs.grayscaleExtraDim().get() && prefs.grayscaleEnabled().get()
+
+        if (serviceRunning) {
+            DetoxUtil.setExtraDim(context, newValue)
+        }
+
+        deviceIsCurrentlyExtraDim = serviceRunning && newValue
+        updateSummary()
+    }
+
+    private fun updateSummary() {
+        summary = SpannableStringBuilder()
+            .apply {
+                if (deviceIsCurrentlyExtraDim) {
+                    append(context.getString(R.string.home_grayscale_extraDim_currently_enabled_description_1))
+
+                    append("\n")
+
+                    bold { append(context.getString(R.string.home_grayscale_extraDim_currently_enabled_description_2)) }
+                } else {
+                    append(context.getString(R.string.home_grayscale_extraDim_currently_disabled_description))
+                }
+            }
+    }
+
+    @SuppressLint("ClickableViewAccessibility") // we perform the click in the gesture detector
+    override fun onBindViewHolder(holder: PreferenceViewHolder?) {
+        super.onBindViewHolder(holder)
+        val icon = holder?.findViewById(android.R.id.icon) as? ImageView
+        val titleView = holder?.findViewById(android.R.id.title)
+        val summaryView = holder?.findViewById(android.R.id.summary)
+
+        listOfNotNull(titleView, summaryView, icon).forEach {
+            it.setOnTouchListener { _, motionEvent ->
+                gestureDetector.onTouchEvent(motionEvent)
+                true
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/flx_apps/digitaldetox/prefs/PreferenceFragment.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/prefs/PreferenceFragment.kt
@@ -1,12 +1,16 @@
 package com.flx_apps.digitaldetox.prefs
 
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.fragment.app.DialogFragment
-import androidx.preference.Preference
-import androidx.preference.PreferenceCategory
-import androidx.preference.isEmpty
+import androidx.preference.*
 import com.flx_apps.digitaldetox.DetoxAccessibilityService
+import com.flx_apps.digitaldetox.DetoxUtil
 import com.flx_apps.digitaldetox.R
 import com.flx_apps.digitaldetox.log
 import com.takisoft.preferencex.PreferenceFragmentCompat

--- a/app/src/main/java/com/flx_apps/digitaldetox/prefs/Prefs.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/prefs/Prefs.kt
@@ -17,6 +17,9 @@ interface Prefs {
     @DefaultBoolean(false)
     fun grayscaleEnabled(): Boolean
 
+    @DefaultBoolean(false)
+    fun grayscaleExtraDim(): Boolean
+
     @DefaultStringSet()
     fun grayscaleExceptions(): Set<String>
 

--- a/app/src/main/res/drawable/ic_extra_dim.xml
+++ b/app/src/main/res/drawable/ic_extra_dim.xml
@@ -1,0 +1,6 @@
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="-20dp"
+    android:insetTop="6dp"
+    android:insetRight="6dp"
+    android:insetBottom="6dp"
+    android:drawable="@drawable/ic_extra_dim_icon" />

--- a/app/src/main/res/drawable/ic_extra_dim_icon.xml
+++ b/app/src/main/res/drawable/ic_extra_dim_icon.xml
@@ -1,0 +1,53 @@
+<!--
+    Copyright (C) 2021 The Android Open Source Project
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:tint="?android:textColorSecondary"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:scaleX="2.97"
+        android:scaleY="2.97"
+        android:translateX="18.36"
+        android:translateY="18.36">
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M17,12.1L15.59,10.69L13.05,13.22V7.05H11.05V13.22L8.51,10.69L7.1,12.1L12.05,17.05L17,12.1Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M2.05,13.05H4.05C4.6,13.05 5.05,12.6 5.05,12.05C5.05,11.5 4.6,11.05 4.05,11.05H2.05C1.5,11.05 1.05,11.5 1.05,12.05C1.05,12.6 1.5,13.05 2.05,13.05Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M20.05,13.05H22.05C22.6,13.05 23.05,12.6 23.05,12.05C23.05,11.5 22.6,11.05 22.05,11.05H20.05C19.5,11.05 19.05,11.5 19.05,12.05C19.05,12.6 19.5,13.05 20.05,13.05Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M11.05,2.05V4.05C11.05,4.6 11.5,5.05 12.05,5.05C12.6,5.05 13.05,4.6 13.05,4.05V2.05C13.05,1.5 12.6,1.05 12.05,1.05C11.5,1.05 11.05,1.5 11.05,2.05Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M11.05,20.05V22.05C11.05,22.6 11.5,23.05 12.05,23.05C12.6,23.05 13.05,22.6 13.05,22.05V20.05C13.05,19.5 12.6,19.05 12.05,19.05C11.5,19.05 11.05,19.5 11.05,20.05Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M6.04,4.63C5.65,4.24 5.01,4.24 4.63,4.63C4.24,5.02 4.24,5.66 4.63,6.04L5.69,7.1C6.08,7.49 6.72,7.49 7.1,7.1C7.49,6.71 7.49,6.07 7.1,5.69L6.04,4.63Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M18.41,17C18.02,16.61 17.38,16.61 17,17C16.61,17.39 16.61,18.03 17,18.41L18.06,19.47C18.45,19.86 19.09,19.86 19.47,19.47C19.86,19.08 19.86,18.44 19.47,18.06L18.41,17Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M19.47,6.04C19.86,5.65 19.86,5.01 19.47,4.63C19.08,4.24 18.44,4.24 18.06,4.63L17,5.69C16.61,6.08 16.61,6.72 17,7.1C17.39,7.49 18.03,7.49 18.41,7.1L19.47,6.04Z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M7.1,18.41C7.49,18.02 7.49,17.38 7.1,17C6.71,16.61 6.07,16.61 5.69,17L4.63,18.06C4.24,18.45 4.24,19.09 4.63,19.47C5.02,19.86 5.66,19.86 6.04,19.47L7.1,18.41Z" />
+    </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,11 @@
     <string name="home.grayscale">Automatic Grayscale</string>
     <string name="home.grayscale.subtitle">Color up by coloring down your phone</string>
     <string name="home.grayscale.description">Apps compete for your attention, and colors can have an enticing, manipulative effect. With DetoxDroid, you can strip away all the neuron-stimulating colors, while allowing exceptions where necessary.</string>
+    <string name="home.grayscale.extraDim">Extra Dim</string>
+    <string name="home.grayscale.extraDim.key">grayscaleExtraDim</string>
+    <string name="home.grayscale.extraDim.currently_disabled.description">Make your screen even dimmer.</string>
+    <string name="home.grayscale.extraDim.currently_enabled.description.1">Your screen is now extra dim.</string>
+    <string name="home.grayscale.extraDim.currently_enabled.description.2">Long-press to adjust intensity.</string>
     <string name="home.grayscale.ignoreNonFullScreen">Ignore Non-Fullscreen Apps</string>
     <string name="home.grayscale.ignoreNonFullScreen.description">Non-fullscreen components (e.g. sound volume box, status bar) will be ignored, i.e. the color state will not be changed.</string>
     <string name="home.grayscale.exceptions.states.gray">Gray</string>

--- a/app/src/main/res/xml/preferences_grayscale.xml
+++ b/app/src/main/res/xml/preferences_grayscale.xml
@@ -1,5 +1,9 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+    <com.flx_apps.digitaldetox.prefs.ExtraDimPreference
+        app:icon="@drawable/ic_extra_dim"
+        app:key="@string/home.grayscale.extraDim.key"
+        app:title="@string/home.grayscale.extraDim" />
     <CheckBoxPreference
         app:icon="@drawable/ic_non_fullscreen"
         app:key="grayscaleIgnoreNonFullScreen"


### PR DESCRIPTION
# Purpose
Reduce screen brightness (hereafter 'extra dim') is a secure system setting that was added with Android 12 that allows the user to dim their screen below the least normal brightness level. Great if you're using your device in a dark room or in bed! 

This PR adds the ability to enable extra dim whenever the screen grayscale is enabled.

# Appearance
- 'Extra Dim' appears as a new option nested under `Automatic Grayscale`. The icon used is the same icon that is shown in the 'Extra dim' AOSP [quick tile](https://github.com/GrapheneOS/platform_frameworks_base/blob/bff944d05cd47d2b3b713565d3f00d512840d282/packages/SystemUI/src/com/android/systemui/qs/tiles/ReduceBrightColorsTile.java) (albeit with slightly different insets)

  | Disabled | Enabled |
  | --- | --- |
  | <img src="https://user-images.githubusercontent.com/78372052/191649021-98547801-ff57-45bf-bba8-af5baf4ff3e1.png" width="300"/> | <img src="https://user-images.githubusercontent.com/78372052/191650372-3934d7a5-94f1-4c47-a92e-5da1df2c58c9.png" width="300"/> |

# Functionality
- If the detox service is running and grayscale is enabled, any toggling of the 'Extra Dim' checkbox will immediately reflect on the device screen (see video below)
- if the detox service is stopped and grayscale was enabled and extra dim was enabled, extra dim will be turned off just as the grayscale is. The user's preference will _not_ be altered in `SharedPreferences` so it can take effect the next time the detox service is started (see video below)
- if the detox service is running and grayscale is enabled and 'Extra Dim' is enabled, long-pressing on the 'Extra Dim' icon/title/summary will take you to the system settings for 'Extra Dim' where you can change the intensity of the dimness (see video below)
- I've added a new custom `CheckboxPreference` called `ExtraDimPreference` that encapsulates all of the above logic

# Video
Here is a video of this in action taken on GrapheneOS Android 13 build `TP1A.220624.014.2022083000` (video and not a screen recording since the latter doesn't actually reflect the dimming of the screen):

https://user-images.githubusercontent.com/78372052/191652486-a73ab71d-51fc-41d8-9d07-a8b22bab90cd.mp4